### PR TITLE
fix: no longer need `load_dotenv()` per run

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -1,9 +1,6 @@
 import asyncio
-from dotenv import load_dotenv
 from tetra_rp import remote, LiveServerless
 
-# Load environment variables from .env file
-load_dotenv()
 
 # Configuration for a GPU resource
 gpu_config = LiveServerless(

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -1,9 +1,6 @@
 import asyncio
-from dotenv import load_dotenv
 from tetra_rp import remote, LiveServerless
 
-# Load environment variables from .env file
-load_dotenv()
 
 # Configuration for a simple resource
 simple_config = LiveServerless(

--- a/examples/inspect_gpu.py
+++ b/examples/inspect_gpu.py
@@ -1,9 +1,6 @@
 import asyncio
-from dotenv import load_dotenv
 from tetra_rp import remote, LiveServerless, GpuGroup
 
-# Load environment variables from .env file
-load_dotenv()
 
 # Configuration for a GPU resource
 gpu_config = LiveServerless(

--- a/examples/matrix_operations.py
+++ b/examples/matrix_operations.py
@@ -1,9 +1,6 @@
 import asyncio
-from dotenv import load_dotenv
 from tetra_rp import remote, LiveServerless, GpuGroup
 
-# Load environment variables from .env file
-load_dotenv()
 
 # Configuration for a GPU resource
 gpu_config = LiveServerless(

--- a/examples/protein_folding.py
+++ b/examples/protein_folding.py
@@ -1,9 +1,6 @@
 import asyncio
-from dotenv import load_dotenv
 from tetra_rp import remote, LiveServerless, GpuGroup
 
-# Load environment variables from .env file
-load_dotenv()
 
 # Configuration for a GPU resource
 gpu_config = LiveServerless(

--- a/examples/protein_structure_prediction.py
+++ b/examples/protein_structure_prediction.py
@@ -1,9 +1,6 @@
 import asyncio
-from dotenv import load_dotenv
 from tetra_rp import remote, LiveServerless, GpuGroup
 
-# Load environment variables from .env file
-load_dotenv()
 
 # Configuration for a GPU resource
 gpu_config = LiveServerless(

--- a/examples/tensor_test.py
+++ b/examples/tensor_test.py
@@ -1,9 +1,6 @@
 import asyncio
-from dotenv import load_dotenv
 from tetra_rp import remote, LiveServerless, GpuGroup
 
-# Load environment variables from .env file
-load_dotenv()
 
 # Configuration for a GPU resource
 gpu_config = LiveServerless(


### PR DESCRIPTION
Requires https://github.com/runpod/tetra-rp/pull/37
This is implicit in Tetra library now