### PR TITLE
feat: Inspect sandbox runtime example

### DIFF
--- a/examples/cpu_live_serverless.py
+++ b/examples/cpu_live_serverless.py
@@ -30,41 +30,6 @@ def cpu_data_processing(data):
     }
 
 
-# Define another function to run on Runpod CPU
-@remote(
-    resource_config=cpu_live_serverless,
-    dependencies=["psutil",],
-)
-def inspect_cpu_machine():
-    import platform
-    import psutil
-
-    print("CPU Information")
-    print("----------------")
-    print(f"Processor: {platform.processor()}")
-    print(f"Machine: {platform.machine()}")
-    print(f"Platform: {platform.platform()}")
-    print(f"CPU cores: {psutil.cpu_count(logical=False)}")
-    print(f"Logical CPUs: {psutil.cpu_count(logical=True)}")
-    print(f"CPU Frequency: {psutil.cpu_freq().max:.2f} MHz")
-    print()
-
-    print("Memory Information")
-    print("------------------")
-    virtual_mem = psutil.virtual_memory()
-    print(f"Total RAM: {virtual_mem.total / 1e9:.2f} GB")
-    print(f"Available RAM: {virtual_mem.available / 1e9:.2f} GB")
-    print(f"Used RAM: {virtual_mem.used / 1e9:.2f} GB")
-    print()
-
-    print("OS Information")
-    print("--------------")
-    print(f"System: {platform.system()}")
-    print(f"Release: {platform.release()}")
-    print(f"Version: {platform.version()}")
-    print(f"Architecture: {platform.architecture()[0]}")
-    print()
-
 async def main_live_cpu_example():
     # Sample data
     sample_data = [
@@ -86,9 +51,6 @@ async def main_live_cpu_example():
     print(f"Processed {result['row_count']} rows on {result['platform']}")
     print(f"Mean values: {result['mean_values']}")
     print("\n")
-
-    # Run the other function to inspect the CPU machine
-    await inspect_cpu_machine()
 
 
 if __name__ == "__main__":

--- a/examples/inspect_runtime_volume.py
+++ b/examples/inspect_runtime_volume.py
@@ -1,0 +1,118 @@
+import asyncio
+from tetra_rp import remote, LiveServerless, CpuInstanceType
+
+cpu_endpoint = LiveServerless(
+    name="example_inspect_runtime_volume",
+    instanceIds=[CpuInstanceType.CPU3G_1_4],
+)
+
+
+@remote(
+    resource_config=cpu_endpoint,
+    dependencies=[
+        "psutil",
+    ],
+)
+def inspect_runtime_volume():
+    import platform
+    import psutil
+    import os
+    import sys
+    import subprocess
+
+    print("CPU Information")
+    print("----------------")
+    print(f"Processor: {platform.processor()}")
+    print(f"Machine: {platform.machine()}")
+    print(f"Platform: {platform.platform()}")
+    print(f"CPU cores: {psutil.cpu_count(logical=False)}")
+    print(f"Logical CPUs: {psutil.cpu_count(logical=True)}")
+    print(f"CPU Frequency: {psutil.cpu_freq().max:.2f} MHz")
+    print()
+
+    print("Memory Information")
+    print("------------------")
+    virtual_mem = psutil.virtual_memory()
+    print(f"Total RAM: {virtual_mem.total / 1e9:.2f} GB")
+    print(f"Available RAM: {virtual_mem.available / 1e9:.2f} GB")
+    print(f"Used RAM: {virtual_mem.used / 1e9:.2f} GB")
+    print()
+
+    print("OS Information")
+    print("--------------")
+    print(f"System: {platform.system()}")
+    print(f"Release: {platform.release()}")
+    print(f"Version: {platform.version()}")
+    print(f"Architecture: {platform.architecture()[0]}")
+    print()
+
+    print("Python Environment")
+    print("------------------")
+    print(f"Python Version: {sys.version}")
+    print(f"Python Executable: {sys.executable}")
+    print(f"Python Path: {sys.path[:3]}...")  # Show first 3 paths
+    print()
+
+    def list_directory_with_sizes(directory, indent="", max_depth=3, current_depth=0):
+        """Recursively list directory contents with sizes."""
+        if current_depth >= max_depth:
+            return
+
+        try:
+            if not os.path.exists(directory):
+                print(f"{indent}Directory does not exist")
+                return
+
+            items = os.listdir(directory)
+            for item in sorted(items)[:20]:  # Limit to first 20 items per directory
+                item_path = os.path.join(directory, item)
+                if os.path.isdir(item_path):
+                    # Get directory size using du -sh
+                    try:
+                        du_result = subprocess.run(
+                            ["du", "-sh", item_path],
+                            capture_output=True,
+                            text=True,
+                            timeout=10,
+                        )
+                        if du_result.returncode == 0:
+                            size_info = du_result.stdout.split("\t")[0]
+                            print(f"{indent}📁 {item}/ ({size_info})")
+                        else:
+                            print(f"{indent}📁 {item}/")
+                    except:
+                        print(f"{indent}📁 {item}/")
+
+                    # Recursively list subdirectories, especially for runtimes
+                    if item == "runtimes" or current_depth < 1:
+                        list_directory_with_sizes(
+                            item_path, indent + "  ", max_depth, current_depth + 1
+                        )
+
+                else:
+                    size = os.path.getsize(item_path)
+                    print(f"{indent}📄 {item} ({size} bytes)")
+
+            if len(items) > 20:
+                print(f"{indent}... and {len(items) - 20} more items")
+
+        except PermissionError:
+            print(f"{indent}Permission denied")
+        except Exception as e:
+            print(f"{indent}Error: {e}")
+
+    print("Directory Listings with Sizes")
+    print("-----------------------------")
+    for directory in [
+        "/runpod-volume",
+    ]:
+        print(f"\n{directory}:")
+        list_directory_with_sizes(directory)
+    print()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(inspect_runtime_volume())
+    except Exception as e:
+        print(f"❌ An error occurred: {e}")


### PR DESCRIPTION
This is an example demonstrating https://github.com/runpod-workers/worker-tetra/pull/10
```
2025-08-04 02:26:52,463 | INFO  | Remote | CPU Information
2025-08-04 02:26:52,463 | INFO  | Remote | ----------------
2025-08-04 02:26:52,463 | INFO  | Remote | Processor: 
2025-08-04 02:26:52,463 | INFO  | Remote | Machine: x86_64
2025-08-04 02:26:52,463 | INFO  | Remote | Platform: Linux-6.5.0-35-generic-x86_64-with-glibc2.36
2025-08-04 02:26:52,464 | INFO  | Remote | CPU cores: 96
2025-08-04 02:26:52,464 | INFO  | Remote | Logical CPUs: 192
2025-08-04 02:26:52,464 | INFO  | Remote | CPU Frequency: 2400.00 MHz
2025-08-04 02:26:52,464 | INFO  | Remote | 
2025-08-04 02:26:52,464 | INFO  | Remote | Memory Information
2025-08-04 02:26:52,464 | INFO  | Remote | ------------------
2025-08-04 02:26:52,464 | INFO  | Remote | Total RAM: 810.86 GB
2025-08-04 02:26:52,465 | INFO  | Remote | Available RAM: 713.50 GB
2025-08-04 02:26:52,465 | INFO  | Remote | Used RAM: 91.32 GB
2025-08-04 02:26:52,465 | INFO  | Remote | 
2025-08-04 02:26:52,465 | INFO  | Remote | OS Information
2025-08-04 02:26:52,465 | INFO  | Remote | --------------
2025-08-04 02:26:52,465 | INFO  | Remote | System: Linux
2025-08-04 02:26:52,465 | INFO  | Remote | Release: 6.5.0-35-generic
2025-08-04 02:26:52,465 | INFO  | Remote | Version: #35~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue May  7 09:00:52 UTC 2
2025-08-04 02:26:52,466 | INFO  | Remote | Architecture: 64bit
2025-08-04 02:26:52,466 | INFO  | Remote | 
2025-08-04 02:26:52,466 | INFO  | Remote | Python Environment
2025-08-04 02:26:52,466 | INFO  | Remote | ------------------
2025-08-04 02:26:52,466 | INFO  | Remote | Python Version: 3.12.11 (main, Jul 22 2025, 01:45:44) [GCC 12.2.0]
2025-08-04 02:26:52,466 | INFO  | Remote | Python Executable: /app/.venv/bin/python3
2025-08-04 02:26:52,466 | INFO  | Remote | Python Path: ['/runpod-volume/runtimes/5znz34kuckafsw/.venv/lib/python3.12/site-packages', '/app', '/tetra-rp/src']...
2025-08-04 02:26:52,466 | INFO  | Remote | 
2025-08-04 02:26:52,466 | INFO  | Remote | Directory Listings with Sizes
2025-08-04 02:26:52,467 | INFO  | Remote | -----------------------------
2025-08-04 02:26:52,467 | INFO  | Remote | 
2025-08-04 02:26:52,467 | INFO  | Remote | /runpod-volume:
2025-08-04 02:26:52,467 | INFO  | Remote | 📁 .hf-cache/ (512)
2025-08-04 02:26:52,467 | INFO  | Remote | 📁 .uv-cache/ (2.9M)
2025-08-04 02:26:52,468 | INFO  | Remote |   📄 .gitignore (1 bytes)
2025-08-04 02:26:52,468 | INFO  | Remote |   📄 CACHEDIR.TAG (43 bytes)
2025-08-04 02:26:52,468 | INFO  | Remote |   📁 interpreter-v4/ (2.0M)
2025-08-04 02:26:52,468 | INFO  | Remote |   📁 sdists-v9/ (512)
2025-08-04 02:26:52,468 | INFO  | Remote | 📁 runtimes/ (12M)
2025-08-04 02:26:52,469 | INFO  | Remote |   📁 5znz34kuckafsw/ (11M)
```